### PR TITLE
Do not wrap AsyncIterator and Coroutine with extra Coroutine in async functions

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1286,7 +1286,7 @@ class SemanticAnalyzer(
         """
         for fdef in defn.items:
             assert isinstance(fdef, Decorator)
-            if not fdef.func.is_async_generator:
+            if not fdef.func.is_async_generator and fdef.func.is_coroutine:
                 # If it was *not* identified as an async generator, then we wrapped it
                 # with erroneous Coroutine before. Remove this wrapper and record that.
                 fdef.func.is_async_generator = True

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -979,9 +979,13 @@ class SemanticAnalyzer(
             and isinstance(defn.type, CallableType)
             and self.wrapped_coro_return_types.get(defn) != defn.type
         ):
-            if defn.is_async_generator:
-                # Async generator types are handled elsewhere
+            ret_typeinfo = getattr(defn.type.ret_type, "type", None)
+            if ret_typeinfo and ret_typeinfo.has_base("typing.AsyncIterator"):
+                defn.is_coroutine = True
+                defn.is_async_generator = True
                 pass
+            elif ret_typeinfo and ret_typeinfo.has_base("typing.Awaitable"):
+                defn.is_coroutine = True
             else:
                 # A coroutine defined as `async def foo(...) -> T: ...`
                 # has external return type `Coroutine[Any, Any, T]`.
@@ -1274,28 +1278,6 @@ class SemanticAnalyzer(
                 impl.abstract_status = IMPLICITLY_ABSTRACT
             if impl.abstract_status != NOT_ABSTRACT:
                 impl.is_trivial_body = True
-
-        if impl.is_async_generator:
-            self.propagate_async_generator_overloads(defn)
-
-    def propagate_async_generator_overloads(self, defn: OverloadedFuncDef) -> None:
-        """Propagate async generator status from implementation to overloads.
-
-        `is_async_generator` is set based on `yield` presence in function body. With
-        trivial body of an overload this produces incorrect results.
-        """
-        for fdef in defn.items:
-            assert isinstance(fdef, Decorator)
-            if not fdef.func.is_async_generator and fdef.func.is_coroutine:
-                # If it was *not* identified as an async generator, then we wrapped it
-                # with erroneous Coroutine before. Remove this wrapper and record that.
-                fdef.func.is_async_generator = True
-                fdef.func.is_generator = True
-                if (ftype := fdef.func.type) is not None:
-                    assert isinstance(ftype, CallableType)
-                    ret_type = get_proper_type(ftype.ret_type)
-                    assert isinstance(ret_type, Instance)
-                    fdef.func.type = ftype.copy_modified(ret_type=ret_type.args[2])
 
     def analyze_overload_sigs_and_impl(
         self, defn: OverloadedFuncDef

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -177,8 +177,6 @@ async def f() -> None:
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
 [out]
-main:7: error: "Coroutine[Any, Any, AsyncGenerator[str, None]]" has no attribute "__aiter__" (not async iterable)
-main:7: note: Maybe you forgot to use "await"?
 
 [case testAsyncForErrorCanBeIgnored]
 
@@ -683,14 +681,13 @@ from typing import AsyncGenerator, Any
 async def f() -> AsyncGenerator[Any, Any]:
     yield None
 
-async def h() -> Any:
+async def h() -> Any:  # E: The return type of an async generator function should be "AsyncGenerator" or one of its supertypes
     yield 0
 
 async def g():  # E: Function is missing a return type annotation
     yield 0
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
-[out]
 
 [case testAsyncOverloadedFunction]
 from typing import overload
@@ -915,7 +912,7 @@ async def f() -> AsyncGenerator[int, None]:
     async def g(x: int) -> int:
         return x
 
-    return (await g(x) for x in [1, 2, 3])
+    return (await g(x) for x in [1, 2, 3])  # E: "return" with value in async generator is not allowed
 
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
@@ -1054,10 +1051,10 @@ class P(Protocol):
         raise BaseException
 
 class Launcher(P):
-    def launch(self) -> AsyncIterator[int]:  # E: Return type "AsyncIterator[int]" of "launch" incompatible with return type "Coroutine[Any, Any, AsyncIterator[int]]" in supertype "P" \
-                                             # N: Consider declaring "launch" in supertype "P" without "async" \
-                                             # N: See https://mypy.readthedocs.io/en/stable/more_types.html#asynchronous-iterators
+    def launch(self) -> AsyncIterator[int]:
         raise BaseException
+
+
 
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3383,23 +3383,25 @@ for factory in (
     var = factory()
 [builtins fixtures/tuple.pyi]
 
-[case testAyncContextManagerOverload]
-from contextlib import asynccontextmanager
-from typing import AsyncIterator, Iterator, Union, overload
+[case testAsyncIteratorOverload]
+from typing import AsyncIterator, Callable, Iterator, TypeVar, Union, overload
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def deco(fn: Callable[[T], AsyncIterator[U]]) -> Callable[[T], U]:
+    ...
 
 @overload
-@asynccontextmanager
+@deco
 async def test_async(val: int) -> AsyncIterator[int]: ...
 
 @overload
-@asynccontextmanager
-async def test_async(val: str) -> AsyncIterator[str]: ...  # E: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader
+@deco
+async def test_async(val: str) -> AsyncIterator[str]: ...
 
-# NB: the error above is caused by naive `asynccontextmanager` definition in test stubs.
-
-@asynccontextmanager
+@deco
 async def test_async(val: Union[int, str]) -> AsyncIterator[Union[int, str]]:
     yield val
 
-[typing fixtures/typing-full.pyi]
-[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-async.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3405,3 +3405,26 @@ async def test_async(val: Union[int, str]) -> AsyncIterator[Union[int, str]]:
     yield val
 
 [typing fixtures/typing-async.pyi]
+
+[case testAsyncIteratorOverloadMixedAsync]
+from typing import AsyncIterator, Callable, Iterator, TypeVar, Union, overload
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def deco(fn: Callable[[T], AsyncIterator[U]]) -> Callable[[T], U]:
+    ...
+
+@overload
+@deco
+def test_async(val: int) -> AsyncIterator[int]: ...
+
+@overload
+@deco
+def test_async(val: str) -> AsyncIterator[str]: ...
+
+@deco
+async def test_async(val: Union[int, str]) -> AsyncIterator[Union[int, str]]:
+    yield val
+
+[typing fixtures/typing-async.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3382,3 +3382,24 @@ for factory in (
     reveal_type(factory)  # N: Revealed type is "def () -> Union[builtins.str, None]"
     var = factory()
 [builtins fixtures/tuple.pyi]
+
+[case testAyncContextManagerOverload]
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Iterator, Union, overload
+
+@overload
+@asynccontextmanager
+async def test_async(val: int) -> AsyncIterator[int]: ...
+
+@overload
+@asynccontextmanager
+async def test_async(val: str) -> AsyncIterator[str]: ...  # E: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader
+
+# NB: the error above is caused by naive `asynccontextmanager` definition in test stubs.
+
+@asynccontextmanager
+async def test_async(val: Union[int, str]) -> AsyncIterator[Union[int, str]]:
+    yield val
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Experiment for https://discuss.python.org/t/overloads-of-async-generators-inconsistent-coroutine-wrapping/